### PR TITLE
Allow downloading pngs, supported now on dropbox

### DIFF
--- a/src/lib/abstractimagedownloader.h
+++ b/src/lib/abstractimagedownloader.h
@@ -44,16 +44,17 @@ protected:
 
     static QString makeOutputFile(SocialSyncInterface::SocialNetwork socialNetwork,
                                   SocialSyncInterface::DataType dataType,
-                                  const QString &identifier);
-    static QString makeOutputFile(SocialSyncInterface::SocialNetwork socialNetwork,
-                                  SocialSyncInterface::DataType dataType,
                                   const QString &identifier,
-                                  const QString &remoteUrl); // added to retain BC.
-
+                                  const QString &mimeType);
+    static QString makeUrlOutputFile(SocialSyncInterface::SocialNetwork socialNetwork,
+                                     SocialSyncInterface::DataType dataType,
+                                     const QString &identifier,
+                                     const QString &remoteUrl,
+                                     const QString &mimeType);
     virtual QNetworkReply * createReply(const QString &url, const QVariantMap &metadata);
 
     // Output file based on passed data
-    virtual QString outputFile(const QString &url, const QVariantMap &metadata) const = 0;
+    virtual QString outputFile(const QString &url, const QVariantMap &metadata, const QString &mimetype) const = 0;
 
     // Init the database if not initialized
     // used to delay initialization of the database

--- a/src/lib/abstractimagedownloader_p.h
+++ b/src/lib/abstractimagedownloader_p.h
@@ -43,10 +43,10 @@
 
 struct ImageInfo
 {
-    ImageInfo(const QString &url, const QVariantMap &data) : url(url), requestsData(QList<QVariantMap>() << data) {}
+    ImageInfo(const QString &url, const QVariantMap &data)
+        : url(url), requestsData(QList<QVariantMap>() << data) {}
 
     QString url;
-    QString fileName;
     QString redirectUrl;
     QList<QVariantMap> requestsData;
 };
@@ -65,6 +65,8 @@ protected:
 
 private:
     void manageStack();
+    bool writeImageData(ImageInfo *imageInfo, QNetworkReply *reply, QString *outFileName);
+
     QMap<QNetworkReply *, ImageInfo *> runningReplies;
     QMap<QTimer *, QNetworkReply *> replyTimeouts;
     QList<ImageInfo *> stack;

--- a/src/lib/facebookcontactsdatabase.cpp
+++ b/src/lib/facebookcontactsdatabase.cpp
@@ -31,8 +31,8 @@
 static const char *DB_NAME = "facebook.db";
 static const int VERSION = 3;
 
-static const char *PICTURE_FILE_KEY = "pictureFile";
-static const char *COVER_FILE_KEY = "coverFile";
+//static const char *PICTURE_FILE_KEY = "pictureFile";
+//static const char *COVER_FILE_KEY = "coverFile";
 
 struct FacebookContactPrivate
 {

--- a/src/qml/dropbox/dropboximagedownloader.cpp
+++ b/src/qml/dropbox/dropboximagedownloader.cpp
@@ -82,7 +82,8 @@ void DropboxImageDownloader::invokeSpecificModelCallback(const QString &url, con
 }
 
 QString DropboxImageDownloader::outputFile(const QString &url,
-                                           const QVariantMap &data) const
+                                           const QVariantMap &data,
+                                           const QString &mimeType) const
 {
     Q_UNUSED(url);
 
@@ -99,7 +100,7 @@ QString DropboxImageDownloader::outputFile(const QString &url,
 
     identifier.append(typeString);
 
-    return makeOutputFile(SocialSyncInterface::Dropbox, SocialSyncInterface::Images, identifier);
+    return makeOutputFile(SocialSyncInterface::Dropbox, SocialSyncInterface::Images, identifier, mimetype);
 }
 
 void DropboxImageDownloader::dbQueueImage(const QString &url, const QVariantMap &data,

--- a/src/qml/dropbox/dropboximagedownloader.h
+++ b/src/qml/dropbox/dropboximagedownloader.h
@@ -44,7 +44,7 @@ public:
     void removeModelFromHash(DropboxImageCacheModel *model);
 
 protected:
-    QString outputFile(const QString &url, const QVariantMap &data) const;
+    QString outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const override;
 
     void dbQueueImage(const QString &url, const QVariantMap &data, const QString &file);
     void dbWrite();

--- a/src/qml/facebook/facebookimagedownloader.cpp
+++ b/src/qml/facebook/facebookimagedownloader.cpp
@@ -82,9 +82,11 @@ void FacebookImageDownloader::invokeSpecificModelCallback(const QString &url, co
 }
 
 QString FacebookImageDownloader::outputFile(const QString &url,
-                                                        const QVariantMap &data) const
+                                            const QVariantMap &data,
+                                            const QString &mimeType) const
 {
     Q_UNUSED(url);
+    Q_UNUSED(mimeType); // TODO: use?
 
     // We create the identifier by appending the type to the real identifier
     QString identifier = data.value(QLatin1String(IDENTIFIER_KEY)).toString();
@@ -99,7 +101,7 @@ QString FacebookImageDownloader::outputFile(const QString &url,
 
     identifier.append(typeString);
 
-    return makeOutputFile(SocialSyncInterface::Facebook, SocialSyncInterface::Images, identifier);
+    return makeOutputFile(SocialSyncInterface::Facebook, SocialSyncInterface::Images, identifier, QString());
 }
 
 void FacebookImageDownloader::dbQueueImage(const QString &url, const QVariantMap &data,

--- a/src/qml/facebook/facebookimagedownloader.h
+++ b/src/qml/facebook/facebookimagedownloader.h
@@ -44,7 +44,7 @@ public:
     void removeModelFromHash(FacebookImageCacheModel *model);
 
 protected:
-    QString outputFile(const QString &url, const QVariantMap &data) const;
+    QString outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const override;
 
     void dbQueueImage(const QString &url, const QVariantMap &data, const QString &file);
     void dbWrite();

--- a/src/qml/generic/socialimagedownloader.cpp
+++ b/src/qml/generic/socialimagedownloader.cpp
@@ -127,7 +127,8 @@ void SocialImageDownloader::imageFile(const QString &imageUrl,
     data.insert(QStringLiteral("accountId"), accountId);
     data.insert(QStringLiteral("expiresInDays"), expiresInDays);
     data.insert(QStringLiteral("imageId"), imageId);
-    if (accessToken.length()) data.insert(QStringLiteral("accessToken"), accessToken);
+    if (accessToken.length())
+        data.insert(QStringLiteral("accessToken"), accessToken);
     queue(imageUrl, data);
     return;
 }
@@ -195,7 +196,8 @@ void SocialImageDownloader::notifyImageCached(const QString &imageUrl,
 }
 
 QString SocialImageDownloader::outputFile(const QString &url,
-                                          const QVariantMap &data) const
+                                          const QVariantMap &data,
+                                          const QString &mimeType) const
 {
     Q_UNUSED(data);
 
@@ -210,8 +212,12 @@ QString SocialImageDownloader::outputFile(const QString &url,
         ending = parts.last();
     }
     if (ending.isEmpty()) {
-        // assume jpg
-        ending = "jpg";
+        if (mimeType == QStringLiteral("image/png")) {
+            ending = QStringLiteral("png");
+        } else {
+            // assume jpg
+            ending = "jpg";
+        }
     }
 
     QCryptographicHash hash (QCryptographicHash::Md5);

--- a/src/qml/generic/socialimagedownloader.h
+++ b/src/qml/generic/socialimagedownloader.h
@@ -43,7 +43,7 @@ public:
     Q_INVOKABLE void removeFromRecentlyUsedById(const QString &imageId);
 
 protected:
-    QString outputFile(const QString &url, const QVariantMap &data) const;
+    QString outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const override;
 
 private Q_SLOTS:
     void notifyImageCached(const QString &url, const QString &path, const QVariantMap &metadata);

--- a/src/qml/onedrive/onedriveimagedownloader.cpp
+++ b/src/qml/onedrive/onedriveimagedownloader.cpp
@@ -34,7 +34,7 @@
 
 static const char *MODEL_KEY = "model";
 static const char *URL_KEY = "url";
-static const char *TYPE_PHOTO = "photo";
+// static const char *TYPE_PHOTO = "photo";
 
 OneDriveImageDownloader::UncachedImage::UncachedImage()
 {}

--- a/src/qml/onedrive/onedriveimagedownloader.cpp
+++ b/src/qml/onedrive/onedriveimagedownloader.cpp
@@ -128,9 +128,11 @@ void OneDriveImageDownloader::invokeSpecificModelCallback(const QString &url, co
 }
 
 QString OneDriveImageDownloader::outputFile(const QString &url,
-                                            const QVariantMap &data) const
+                                            const QVariantMap &data,
+                                            const QString &mimeType) const
 {
     Q_UNUSED(url);
+    Q_UNUSED(mimeType); // TODO: use?
 
     // We create the identifier by appending the type to the real identifier
     QString identifier = data.value(QLatin1String(IDENTIFIER_KEY)).toString();
@@ -145,7 +147,7 @@ QString OneDriveImageDownloader::outputFile(const QString &url,
 
     identifier.append(typeString);
 
-    return makeOutputFile(SocialSyncInterface::OneDrive, SocialSyncInterface::Images, identifier);
+    return makeOutputFile(SocialSyncInterface::OneDrive, SocialSyncInterface::Images, identifier, QString());
 }
 
 void OneDriveImageDownloader::dbQueueImage(const QString &url, const QVariantMap &data, const QString &file)

--- a/src/qml/onedrive/onedriveimagedownloader.h
+++ b/src/qml/onedrive/onedriveimagedownloader.h
@@ -77,7 +77,7 @@ signals:
     void accessTokenRequested(int accountId);
 
 protected:
-    QString outputFile(const QString &url, const QVariantMap &data) const;
+    QString outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const override;
 
     void dbQueueImage(const QString &url, const QVariantMap &data, const QString &file);
     void dbWrite();

--- a/src/qml/vk/vkimagecachemodel.cpp
+++ b/src/qml/vk/vkimagecachemodel.cpp
@@ -263,6 +263,7 @@ void VKImageCacheModel::refresh()
 // performance reasons.
 void VKImageCacheModel::imageDownloaded(const QString &url, const QString &path, const QVariantMap &imageData)
 {
+    Q_UNUSED(url);
     Q_D(VKImageCacheModel);
 
     if (path.isEmpty()) {

--- a/src/qml/vk/vkimagecachemodel.h
+++ b/src/qml/vk/vkimagecachemodel.h
@@ -73,7 +73,8 @@ public:
 
     // since VK doens't use globally-unique identifiers, we need to encode breadcrumb information into the node identifier.
     Q_INVOKABLE QString constructNodeIdentifier(int accountId, const QString &user_id, const QString &album_id, const QString &photo_id);
-    Q_INVOKABLE QVariantMap parseNodeIdentifier(const QString &nid) const; // { "accountId"=int, "user_id"=string, "album_id"=string, "photo_id"=string }
+    // { "accountId"=int, "user_id"=string, "album_id"=string, "photo_id"=string }
+    Q_INVOKABLE QVariantMap parseNodeIdentifier(const QString &nid) const;
     Q_INVOKABLE void removeImage(const QString &imageId);
 
 public Q_SLOTS:

--- a/src/qml/vk/vkimagedownloader.cpp
+++ b/src/qml/vk/vkimagedownloader.cpp
@@ -84,15 +84,16 @@ void VKImageDownloader::invokeSpecificModelCallback(const QString &url, const QS
     }
 }
 
-QString VKImageDownloader::outputFile(const QString &url, const QVariantMap &data) const
+QString VKImageDownloader::outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const
 {
     Q_UNUSED(url);
+    Q_UNUSED(mimeType);
     QString identifier = QStringLiteral("%1-%2-%3-%4")
                          .arg(data.value(QLatin1String(OWNERID_KEY)).toString())
                          .arg(data.value(QLatin1String(ALBUMID_KEY)).toString())
                          .arg(data.value(QLatin1String(PHOTOID_KEY)).toString())
                          .arg(data.value(QLatin1String(TYPE_KEY)).toString());
-    return makeOutputFile(SocialSyncInterface::VK, SocialSyncInterface::Images, identifier);
+    return makeOutputFile(SocialSyncInterface::VK, SocialSyncInterface::Images, identifier, QString());
 }
 
 void VKImageDownloader::dbQueueImage(const QString &url, const QVariantMap &data, const QString &file)

--- a/src/qml/vk/vkimagedownloader.cpp
+++ b/src/qml/vk/vkimagedownloader.cpp
@@ -97,6 +97,7 @@ QString VKImageDownloader::outputFile(const QString &url, const QVariantMap &dat
 
 void VKImageDownloader::dbQueueImage(const QString &url, const QVariantMap &data, const QString &file)
 {
+    Q_UNUSED(url);
     Q_D(VKImageDownloader);
     QString photo_id = data.value(QLatin1String(PHOTOID_KEY)).toString();
     QString album_id = data.value(QLatin1String(ALBUMID_KEY)).toString();

--- a/src/qml/vk/vkimagedownloader.h
+++ b/src/qml/vk/vkimagedownloader.h
@@ -43,7 +43,7 @@ public:
     void removeModelFromHash(VKImageCacheModel *model);
 
 protected:
-    QString outputFile(const QString &url, const QVariantMap &data) const;
+    QString outputFile(const QString &url, const QVariantMap &data, const QString &mimeType) const override;
     void dbQueueImage(const QString &url, const QVariantMap &data, const QString &file);
     void dbWrite();
 


### PR DESCRIPTION
Main commit:

    The file path handling was assuming only jpegs downloaded and forcing
    conversion if something else was encountered. At least png files
    should be fine too so added ability to save as such.
    
    Usage now in DropBox. Others could be added but of course require some
    testing that it behave right. Confusingly downloading the fullscreen
    image from jolla-gallery goes via SocialImageDownloader aka
    SocialImageCache in qml.
    
    For more technical details the AbstractImageDownloader was unnecessarily
    creating the target filename all before the download was even started
    and there was no detailed information on what was going to be gotten.
    Now moved that filepath handling to happen while the server
    reply has been received.
