### PR TITLE
[libsocialcache] Clean up some code details. JB#63850

### DIFF
--- a/src/lib/abstractimagedownloader.cpp
+++ b/src/lib/abstractimagedownloader.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Lucien Xu <sfietkonstantin@free.fr>
- * Copyright (C) 2013 - 2021 Jolla Pty Ltd.
+ * Copyright (C) 2013 - 2021 Jolla Ltd.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -76,7 +76,7 @@ void AbstractImageDownloaderPrivate::manageStack()
             timer->setInterval(60000);
             timer->setSingleShot(true);
             QObject::connect(timer, &QTimer::timeout,
-                    q, &AbstractImageDownloader::timedOut);
+                             q, &AbstractImageDownloader::timedOut);
             timer->start();
             replyTimeouts.insert(timer, reply);
             reply->setProperty("timeoutTimer", QVariant::fromValue<QTimer*>(timer));
@@ -96,6 +96,7 @@ void AbstractImageDownloaderPrivate::manageStack()
 bool AbstractImageDownloaderPrivate::writeImageData(ImageInfo *info, QNetworkReply *reply, QString *outFileName)
 {
     Q_Q(AbstractImageDownloader);
+
     qint64 bytesAvailable = reply->bytesAvailable();
     if (bytesAvailable == 0) {
         qWarning() << Q_FUNC_INFO << "No image data available";
@@ -264,6 +265,7 @@ AbstractImageDownloader::~AbstractImageDownloader()
 void AbstractImageDownloader::queue(const QString &url, const QVariantMap &metadata)
 {
     Q_D(AbstractImageDownloader);
+
     if (!dbInit()) {
         qWarning() << Q_FUNC_INFO << "Cannot perform operation, database is not initialized";
         emit imageDownloaded(url, QString(), metadata); // empty file signifies error.
@@ -279,7 +281,7 @@ void AbstractImageDownloader::queue(const QString &url, const QVariantMap &metad
         }
     }
 
-    ImageInfo *info = 0;
+    ImageInfo *info = nullptr;
     for (int i = 0; i < d->stack.count(); ++i) {
         if (d->stack.at(i)->url == url) {
             qWarning() << Q_FUNC_INFO << "duplicate queued request, appending metadata.";
@@ -300,6 +302,7 @@ void AbstractImageDownloader::queue(const QString &url, const QVariantMap &metad
 QNetworkReply *AbstractImageDownloader::createReply(const QString &url, const QVariantMap &metadata)
 {
     Q_D(AbstractImageDownloader);
+
     QNetworkRequest request (url);
 
     for (QVariantMap::const_iterator iter = metadata.begin(); iter != metadata.end(); ++iter) {

--- a/src/lib/abstractimagedownloader.h
+++ b/src/lib/abstractimagedownloader.h
@@ -31,7 +31,7 @@ class AbstractImageDownloader : public QObject
 {
     Q_OBJECT
 public:
-    AbstractImageDownloader(QObject *parent = 0);
+    AbstractImageDownloader(QObject *parent = nullptr);
     virtual ~AbstractImageDownloader();
 
 public Q_SLOTS:

--- a/src/lib/abstractimagedownloader_p.h
+++ b/src/lib/abstractimagedownloader_p.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Lucien XU <sfietkonstantin@free.fr>
- * Copyright (C) 2013 - 2021 Jolla Pty Ltd.
+ * Copyright (C) 2013 - 2021 Jolla Ltd.
  *
  * You may use this file under the terms of the BSD license as follows:
  *

--- a/src/lib/abstractsocialcachedatabase.cpp
+++ b/src/lib/abstractsocialcachedatabase.cpp
@@ -59,14 +59,14 @@ public:
         if (threadData) {
             threadData->mutex->unlock();
             delete threadData->mutex;
-            threadData->mutex = 0;
+            threadData->mutex = nullptr;
         }
     }
 
     void finalize()
     {
         threadData->mutex->unlock();
-        threadData = 0;
+        threadData = nullptr;
     }
 
 private:
@@ -493,4 +493,3 @@ QSqlQuery AbstractSocialCacheDatabase::prepare(const QString &query) const
         return preparedQuery;
     }
 }
-

--- a/src/lib/abstractsocialcachedatabase.h
+++ b/src/lib/abstractsocialcachedatabase.h
@@ -29,23 +29,22 @@ class QSqlQuery;
 QT_END_NAMESPACE
 
 class AbstractSocialCacheDatabasePrivate;
+
 class AbstractSocialCacheDatabase : public QObject
 {
     Q_OBJECT
 public:
-    enum Status
-    {
+    enum Status {
         Null,
         Executing,
         Finished,
         Error
     };
 
-    explicit AbstractSocialCacheDatabase(
-            const QString &serviceName,
-            const QString &dataType,
-            const QString &databaseFile,
-            int version);
+    AbstractSocialCacheDatabase(const QString &serviceName,
+                                const QString &dataType,
+                                const QString &databaseFile,
+                                int version);
     virtual ~AbstractSocialCacheDatabase();
 
     bool isValid() const;
@@ -75,7 +74,6 @@ protected:
 
     virtual void readFinished();
     virtual void writeFinished();
-
 
     QSqlQuery prepare(const QString &query) const;
 

--- a/src/lib/abstractsocialcachedatabase_p.h
+++ b/src/lib/abstractsocialcachedatabase_p.h
@@ -48,7 +48,7 @@ public:
 
     struct ThreadData
     {
-        ThreadData() : mutex(0) {}
+        ThreadData() : mutex(nullptr) {}
         ~ThreadData() { database.close(); delete mutex; }
 
         QSqlDatabase database;
@@ -57,12 +57,11 @@ public:
         ProcessMutex *mutex; // Process (and thread) mutex to prevent concurrent write
     };
 
-    explicit AbstractSocialCacheDatabasePrivate(
-            AbstractSocialCacheDatabase *q,
-            const QString &serviceName,
-            const QString &dataType,
-            const QString &databaseFile,
-            int version);
+     AbstractSocialCacheDatabasePrivate(AbstractSocialCacheDatabase *q,
+                                       const QString &serviceName,
+                                       const QString &dataType,
+                                       const QString &databaseFile,
+                                       int version);
     virtual ~AbstractSocialCacheDatabasePrivate();
 
     bool initializeThreadData(ThreadData *threadData) const;

--- a/src/lib/abstractsocialpostcachedatabase.cpp
+++ b/src/lib/abstractsocialpostcachedatabase.cpp
@@ -75,10 +75,10 @@ SocialPostImage::ImageType SocialPostImage::type() const
 
 struct SocialPostPrivate
 {
-    explicit SocialPostPrivate(const QString &identifier, const QString &name,
-                               const QString &body, const QDateTime &timestamp,
-                               const QVariantMap &extra = QVariantMap(),
-                               const QList<int> &accounts = QList<int>());
+    SocialPostPrivate(const QString &identifier, const QString &name,
+                      const QString &body, const QDateTime &timestamp,
+                      const QVariantMap &extra = QVariantMap(),
+                      const QList<int> &accounts = QList<int>());
     QString identifier;
     QString name;
     QString body;
@@ -338,11 +338,9 @@ void AbstractSocialPostCacheDatabase::refresh()
 bool AbstractSocialPostCacheDatabase::read()
 {
     Q_D(AbstractSocialPostCacheDatabase);
-    // This might be slow
 
-    QString accountQueryString = QLatin1String(
-                "SELECT account, postId "
-                "FROM link_post_account");
+    // This might be slow
+    QString accountQueryString = QLatin1String("SELECT account, postId FROM link_post_account");
     if (!d->accountIdFilter.isEmpty()) {
         QStringList accountIds;
         for (int i=0; i<d->accountIdFilter.count(); i++) {
@@ -372,9 +370,8 @@ bool AbstractSocialPostCacheDatabase::read()
         }
     }
 
-    QString postQueryString = QLatin1String(
-                "SELECT identifier, name, body, timestamp "
-                "FROM posts");
+    QString postQueryString = QLatin1String("SELECT identifier, name, body, timestamp "
+                                            "FROM posts");
     if (!d->accountIdFilter.isEmpty()) {
         postQueryString += " WHERE identifier IN (\"" + filteredPostIds.join("\",\"") + "\")";
     }

--- a/src/lib/abstractsocialpostcachedatabase.h
+++ b/src/lib/abstractsocialpostcachedatabase.h
@@ -25,10 +25,10 @@
 #include <QtCore/QVariantMap>
 
 class SocialPostImagePrivate;
+
 class SocialPostImage
 {
 public:
-
     enum ImageType {
         Invalid,
         Photo,
@@ -38,7 +38,7 @@ public:
     typedef QSharedPointer<SocialPostImage> Ptr;
     typedef QSharedPointer<const SocialPostImage> ConstPtr;
 
-    explicit SocialPostImage();
+    SocialPostImage();
     virtual ~SocialPostImage();
 
     QString url() const;
@@ -55,6 +55,7 @@ private:
 };
 
 class SocialPostPrivate;
+
 class SocialPost
 {
 public:
@@ -95,13 +96,14 @@ private:
 };
 
 class AbstractSocialPostCacheDatabasePrivate;
+
 class AbstractSocialPostCacheDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT
     Q_PROPERTY(QVariantList accountIdFilter READ accountIdFilter WRITE setAccountIdFilter NOTIFY accountIdFilterChanged)
+
 public:
-    explicit AbstractSocialPostCacheDatabase(
-            const QString &serviceName, const QString &databaseFile);
+    AbstractSocialPostCacheDatabase(const QString &serviceName, const QString &databaseFile);
     ~AbstractSocialPostCacheDatabase();
 
     QVariantList accountIdFilter() const;
@@ -134,10 +136,8 @@ protected:
 
     void readFinished();
 
-
 private:
     Q_DECLARE_PRIVATE(AbstractSocialPostCacheDatabase)
 };
-
 
 #endif // ABSTRACTSOCIALPOSTCACHEDATABASE_H

--- a/src/lib/dropboximagesdatabase.cpp
+++ b/src/lib/dropboximagesdatabase.cpp
@@ -32,8 +32,8 @@ static const int VERSION = 1;
 
 struct DropboxUserPrivate
 {
-    explicit DropboxUserPrivate(const QString &userId, const QDateTime &updatedTime,
-                                 const QString &userName, int count = -1);
+    DropboxUserPrivate(const QString &userId, const QDateTime &updatedTime,
+                       const QString &userName, int count = -1);
     QString userId;
     QDateTime updatedTime;
     QString userName;
@@ -174,13 +174,14 @@ QString DropboxAlbum::hash() const
 
 struct DropboxImagePrivate
 {
-    explicit DropboxImagePrivate(const QString &imageId, const QString &albumId,
-                                  const QString &userId, const QDateTime &createdTime,
-                                  const QDateTime &updatedTime, const QString &imageName,
-                                  int width, int height, const QString &thumbnailUrl,
-                                  const QString &imageUrl, const QString &thumbnailFile,
-                                  const QString &imageFile, int account = -1,
-                                  const QString &accessToken = QString());
+    DropboxImagePrivate(const QString &imageId, const QString &albumId,
+                        const QString &userId, const QDateTime &createdTime,
+                        const QDateTime &updatedTime, const QString &imageName,
+                        int width, int height, const QString &thumbnailUrl,
+                        const QString &imageUrl, const QString &thumbnailFile,
+                        const QString &imageFile, int account = -1,
+                        const QString &accessToken = QString());
+
     QString imageId;
     QString albumId;
     QString userId;
@@ -650,9 +651,8 @@ QMap<int,QString> DropboxImagesDatabase::accounts(bool *ok) const
     }
 
     QMap<int,QString> result;
-    QSqlQuery query = prepare(QStringLiteral(
-                "SELECT accountId, userId "
-                "FROM accounts "));
+    QSqlQuery query = prepare(QStringLiteral("SELECT accountId, userId "
+                                             "FROM accounts "));
     if (!query.exec()) {
         qWarning() << Q_FUNC_INFO << "Unable to fetch account mappings" << query.lastError().text();
         return result;
@@ -1010,6 +1010,7 @@ bool DropboxImagesDatabase::read()
 void DropboxImagesDatabase::readFinished()
 {
     Q_D(DropboxImagesDatabase);
+
     {
         QMutexLocker locker(&d->mutex);
 

--- a/src/lib/dropboximagesdatabase.h
+++ b/src/lib/dropboximagesdatabase.h
@@ -26,6 +26,7 @@
 #include <QtCore/QSharedPointer>
 
 class DropboxUserPrivate;
+
 class DropboxUser
 {
 public:
@@ -35,7 +36,7 @@ public:
     virtual ~DropboxUser();
 
     static DropboxUser::Ptr create(const QString &userId, const QDateTime &updatedTime,
-                                    const QString &userName, int count = -1);
+                                   const QString &userName, int count = -1);
 
     QString userId() const;
     QDateTime updatedTime() const;
@@ -47,11 +48,12 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(DropboxUser)
-    explicit DropboxUser(const QString &userId, const QDateTime &updatedTime,
-                          const QString &userName, int count = -1);
+    DropboxUser(const QString &userId, const QDateTime &updatedTime,
+                const QString &userName, int count = -1);
 };
 
 class DropboxAlbumPrivate;
+
 class DropboxAlbum
 {
 public:
@@ -61,8 +63,8 @@ public:
     virtual ~DropboxAlbum();
 
     static DropboxAlbum::Ptr create(const QString &albumId, const QString &userId,
-                                     const QDateTime &createdTime, const QDateTime &updatedTime,
-                                     const QString &albumName, int imageCount, const QString &hash);
+                                    const QDateTime &createdTime, const QDateTime &updatedTime,
+                                    const QString &albumName, int imageCount, const QString &hash);
 
     QString albumId() const;
     QString userId() const;
@@ -78,11 +80,12 @@ protected:
 private:
     Q_DECLARE_PRIVATE(DropboxAlbum)
     explicit DropboxAlbum(const QString &albumId, const QString &userId,
-                           const QDateTime &createdTime, const QDateTime &updatedTime,
-                           const QString &albumName, int imageCount, const QString &hash);
+                          const QDateTime &createdTime, const QDateTime &updatedTime,
+                          const QString &albumName, int imageCount, const QString &hash);
 };
 
 class DropboxImagePrivate;
+
 class DropboxImage
 {
 public:
@@ -92,12 +95,12 @@ public:
     virtual ~DropboxImage();
 
     static DropboxImage::Ptr create(const QString & imageId, const QString & albumId,
-                                     const QString & userId, const QDateTime & createdTime,
-                                     const QDateTime &updatedTime, const QString &imageName,
-                                     int width, int height, const QString & thumbnailUrl,
-                                     const QString & imageUrl, const QString & thumbnailFile,
-                                     const QString & imageFile, int account = -1,
-                                     const QString & accessToken = QString());
+                                    const QString & userId, const QDateTime & createdTime,
+                                    const QDateTime &updatedTime, const QString &imageName,
+                                    int width, int height, const QString & thumbnailUrl,
+                                    const QString & imageUrl, const QString & thumbnailFile,
+                                    const QString & imageFile, int account = -1,
+                                    const QString & accessToken = QString());
 
     QString imageId() const;
     QString albumId() const;
@@ -119,13 +122,14 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(DropboxImage)
-    explicit DropboxImage(const QString & imageId, const QString & albumId,
-                           const QString & userId, const QDateTime & createdTime,
-                           const QDateTime & updatedTime, const QString & imageName,
-                           int width, int height, const QString & thumbnailUrl,
-                           const QString & imageUrl, const QString & thumbnailFile,
-                           const QString & imageFile, int account = -1,
-                           const QString & accessToken = QString());
+
+    DropboxImage(const QString & imageId, const QString & albumId,
+                 const QString & userId, const QDateTime & createdTime,
+                 const QDateTime & updatedTime, const QString & imageName,
+                 int width, int height, const QString & thumbnailUrl,
+                 const QString & imageUrl, const QString & thumbnailFile,
+                 const QString & imageFile, int account = -1,
+                 const QString & accessToken = QString());
 };
 
 bool operator==(const DropboxUser::ConstPtr &user1, const DropboxUser::ConstPtr &user2);
@@ -133,11 +137,12 @@ bool operator==(const DropboxAlbum::ConstPtr &album1, const DropboxAlbum::ConstP
 bool operator==(const DropboxImage::ConstPtr &image1, const DropboxImage::ConstPtr &image2);
 
 class DropboxImagesDatabasePrivate;
+
 class DropboxImagesDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT
 public:
-    explicit DropboxImagesDatabase();
+    DropboxImagesDatabase();
     ~DropboxImagesDatabase();
 
     // Account manipulation
@@ -147,8 +152,7 @@ public:
 
     // User cache manipulation
     DropboxUser::ConstPtr user(const QString &userId) const;
-    void addUser(const QString &userId, const QDateTime &updatedTime,
-                 const QString &userName);
+    void addUser(const QString &userId, const QDateTime &updatedTime, const QString &userName);
     void removeUser(const QString &userId);
 
     // Album cache manipulation
@@ -194,7 +198,6 @@ protected:
     bool write();
     bool createTables(QSqlDatabase database) const;
     bool dropTables(QSqlDatabase database) const;
-
 
 private:
     Q_DECLARE_PRIVATE(DropboxImagesDatabase)

--- a/src/lib/facebookcontactsdatabase.cpp
+++ b/src/lib/facebookcontactsdatabase.cpp
@@ -36,9 +36,10 @@ static const int VERSION = 3;
 
 struct FacebookContactPrivate
 {
-    explicit FacebookContactPrivate(const QString &fbFriendId, int accountId,
-                                    const QString &pictureUrl, const QString &coverUrl,
-                                    const QString &pictureFile, const QString &coverFile);
+    FacebookContactPrivate(const QString &fbFriendId, int accountId,
+                           const QString &pictureUrl, const QString &coverUrl,
+                           const QString &pictureFile, const QString &coverFile);
+
     QString fbFriendId;
     int accountId;
     QString pictureUrl;

--- a/src/lib/facebookcontactsdatabase.h
+++ b/src/lib/facebookcontactsdatabase.h
@@ -24,6 +24,7 @@
 #include <QtCore/QSharedPointer>
 
 class FacebookContactPrivate;
+
 class FacebookContact
 {
 public:
@@ -39,21 +40,25 @@ public:
     QString coverUrl() const;
     QString pictureFile() const;
     QString coverFile() const;
+
 protected:
     QScopedPointer<FacebookContactPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(FacebookContact)
-    explicit FacebookContact(const QString &fbFriendId, int accountId,
-                             const QString &pictureUrl, const QString &coverUrl,
-                             const QString &pictureFile, const QString &coverFile);
+
+    FacebookContact(const QString &fbFriendId, int accountId,
+                    const QString &pictureUrl, const QString &coverUrl,
+                    const QString &pictureFile, const QString &coverFile);
 };
 
 class FacebookContactsDatabasePrivate;
+
 class FacebookContactsDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT
 public:
-    explicit FacebookContactsDatabase();
+    FacebookContactsDatabase();
     ~FacebookContactsDatabase();
 
     bool removeContacts(int accountId);

--- a/src/lib/facebookimagesdatabase.cpp
+++ b/src/lib/facebookimagesdatabase.cpp
@@ -32,8 +32,9 @@ static const int VERSION = 3;
 
 struct FacebookUserPrivate
 {
-    explicit FacebookUserPrivate(const QString &fbUserId, const QDateTime &updatedTime,
-                                 const QString &userName, int count = -1);
+    FacebookUserPrivate(const QString &fbUserId, const QDateTime &updatedTime,
+                        const QString &userName, int count = -1);
+
     QString fbUserId;
     QDateTime updatedTime;
     QString userName;
@@ -89,9 +90,10 @@ int FacebookUser::count() const
 
 struct FacebookAlbumPrivate
 {
-    explicit FacebookAlbumPrivate(const QString &fbAlbumId, const QString &fbUserId,
-                                  const QDateTime &createdTime, const QDateTime &updatedTime,
-                                  const QString &albumName, int imageCount);
+    FacebookAlbumPrivate(const QString &fbAlbumId, const QString &fbUserId,
+                         const QDateTime &createdTime, const QDateTime &updatedTime,
+                         const QString &albumName, int imageCount);
+
     QString fbAlbumId;
     QString fbUserId;
     QDateTime createdTime;
@@ -167,12 +169,13 @@ int FacebookAlbum::imageCount() const
 
 struct FacebookImagePrivate
 {
-    explicit FacebookImagePrivate(const QString &fbImageId, const QString &fbAlbumId,
-                                  const QString &fbUserId, const QDateTime &createdTime,
-                                  const QDateTime &updatedTime, const QString &imageName,
-                                  int width, int height, const QString &thumbnailUrl,
-                                  const QString &imageUrl, const QString &thumbnailFile,
-                                  const QString &imageFile, int account = -1);
+    FacebookImagePrivate(const QString &fbImageId, const QString &fbAlbumId,
+                         const QString &fbUserId, const QDateTime &createdTime,
+                         const QDateTime &updatedTime, const QString &imageName,
+                         int width, int height, const QString &thumbnailUrl,
+                         const QString &imageUrl, const QString &thumbnailFile,
+                         const QString &imageFile, int account = -1);
+
     QString fbImageId;
     QString fbAlbumId;
     QString fbUserId;

--- a/src/lib/facebookimagesdatabase.h
+++ b/src/lib/facebookimagesdatabase.h
@@ -26,6 +26,7 @@
 #include <QtCore/QSharedPointer>
 
 class FacebookUserPrivate;
+
 class FacebookUser
 {
 public:
@@ -47,11 +48,12 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(FacebookUser)
-    explicit FacebookUser(const QString &fbUserId, const QDateTime &updatedTime,
-                          const QString &userName, int count = -1);
+    FacebookUser(const QString &fbUserId, const QDateTime &updatedTime,
+                 const QString &userName, int count = -1);
 };
 
 class FacebookAlbumPrivate;
+
 class FacebookAlbum
 {
 public:
@@ -82,6 +84,7 @@ private:
 };
 
 class FacebookImagePrivate;
+
 class FacebookImage
 {
 public:
@@ -116,12 +119,12 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(FacebookImage)
-    explicit FacebookImage(const QString & fbImageId, const QString & fbAlbumId,
-                           const QString & fbUserId, const QDateTime & createdTime,
-                           const QDateTime & updatedTime, const QString & imageName,
-                           int width, int height, const QString & thumbnailUrl,
-                           const QString & imageUrl, const QString & thumbnailFile,
-                           const QString & imageFile, int account = -1);
+    FacebookImage(const QString & fbImageId, const QString & fbAlbumId,
+                  const QString & fbUserId, const QDateTime & createdTime,
+                  const QDateTime & updatedTime, const QString & imageName,
+                  int width, int height, const QString & thumbnailUrl,
+                  const QString & imageUrl, const QString & thumbnailFile,
+                  const QString & imageFile, int account = -1);
 };
 
 bool operator==(const FacebookUser::ConstPtr &user1, const FacebookUser::ConstPtr &user2);
@@ -132,8 +135,9 @@ class FacebookImagesDatabasePrivate;
 class FacebookImagesDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT
+
 public:
-    explicit FacebookImagesDatabase();
+    FacebookImagesDatabase();
     ~FacebookImagesDatabase();
 
     // Account manipulation
@@ -190,7 +194,6 @@ protected:
     bool write();
     bool createTables(QSqlDatabase database) const;
     bool dropTables(QSqlDatabase database) const;
-
 
 private:
     Q_DECLARE_PRIVATE(FacebookImagesDatabase)

--- a/src/lib/facebooknotificationsdatabase.cpp
+++ b/src/lib/facebooknotificationsdatabase.cpp
@@ -29,11 +29,11 @@ static const int VERSION = 1;
 
 struct FacebookNotificationPrivate
 {
-    explicit FacebookNotificationPrivate(const QString &facebookId, const QString &from, const QString &to,
-                                         const QDateTime &createdTime, const QDateTime &updatedTime,
-                                         const QString &title, const QString &link,
-                                         const QString &application, const QString &object,
-                                         bool unread, int accountId, const QString &clientId);
+    FacebookNotificationPrivate(const QString &facebookId, const QString &from, const QString &to,
+                                const QDateTime &createdTime, const QDateTime &updatedTime,
+                                const QString &title, const QString &link,
+                                const QString &application, const QString &object,
+                                bool unread, int accountId, const QString &clientId);
 
     QString m_facebookId;
     QString m_from;

--- a/src/lib/facebooknotificationsdatabase.h
+++ b/src/lib/facebooknotificationsdatabase.h
@@ -27,6 +27,7 @@
 #include <QDateTime>
 
 class FacebookNotificationPrivate;
+
 class FacebookNotification
 {
 public:
@@ -53,17 +54,20 @@ public:
 
 protected:
     QScopedPointer<FacebookNotificationPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(FacebookNotification)
-    explicit FacebookNotification(const QString &facebookId, const QString &from, const QString &to,
-                                  const QDateTime &createdTime, const QDateTime &updatedTime,
-                                  const QString &title, const QString &link,
-                                  const QString &application, const QString &object,
-                                  bool unread, int accountId, const QString &clientId);
+
+    FacebookNotification(const QString &facebookId, const QString &from, const QString &to,
+                         const QDateTime &createdTime, const QDateTime &updatedTime,
+                         const QString &title, const QString &link,
+                         const QString &application, const QString &object,
+                         bool unread, int accountId, const QString &clientId);
 };
 
 
 class FacebookNotificationsDatabasePrivate;
+
 class FacebookNotificationsDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT

--- a/src/lib/facebookpostsdatabase.h
+++ b/src/lib/facebookpostsdatabase.h
@@ -25,8 +25,9 @@
 class FacebookPostsDatabase: public AbstractSocialPostCacheDatabase
 {
     Q_OBJECT
+
 public:
-    explicit FacebookPostsDatabase();
+    FacebookPostsDatabase();
     ~FacebookPostsDatabase();
 
     void addFacebookPost(const QString &identifier, const QString &name, const QString &body,

--- a/src/lib/onedriveimagesdatabase.cpp
+++ b/src/lib/onedriveimagesdatabase.cpp
@@ -32,8 +32,9 @@ static const int VERSION = 3;
 
 struct OneDriveUserPrivate
 {
-    explicit OneDriveUserPrivate(const QString &userId, const QDateTime &updatedTime,
-                                 const QString &userName, int accountId, int count = -1);
+    OneDriveUserPrivate(const QString &userId, const QDateTime &updatedTime,
+                        const QString &userName, int accountId, int count = -1);
+
     QString userId;
     QDateTime updatedTime;
     QString userName;
@@ -96,9 +97,10 @@ int OneDriveUser::count() const
 
 struct OneDriveAlbumPrivate
 {
-    explicit OneDriveAlbumPrivate(const QString &albumId, const QString &userId,
-                                  const QDateTime &createdTime, const QDateTime &updatedTime,
-                                  const QString &albumName, int imageCount);
+    OneDriveAlbumPrivate(const QString &albumId, const QString &userId,
+                         const QDateTime &createdTime, const QDateTime &updatedTime,
+                         const QString &albumName, int imageCount);
+
     QString albumId;
     QString userId;
     QDateTime createdTime;
@@ -113,14 +115,12 @@ OneDriveAlbumPrivate::OneDriveAlbumPrivate(const QString &albumId, const QString
     : albumId(albumId), userId(userId), createdTime(createdTime)
     , updatedTime(updatedTime), albumName(albumName), imageCount(imageCount)
 {
-
 }
 
 OneDriveAlbum::OneDriveAlbum(const QString &albumId, const QString &userId,
                              const QDateTime &createdTime, const QDateTime &updatedTime,
                              const QString &albumName, int imageCount)
-    : d_ptr(new OneDriveAlbumPrivate(albumId, userId, createdTime, updatedTime,
-                                     albumName, imageCount))
+    : d_ptr(new OneDriveAlbumPrivate(albumId, userId, createdTime, updatedTime, albumName, imageCount))
 {
 }
 
@@ -174,13 +174,14 @@ int OneDriveAlbum::imageCount() const
 
 struct OneDriveImagePrivate
 {
-    explicit OneDriveImagePrivate(const QString &imageId, const QString &albumId,
-                                  const QString &userId, const QDateTime &createdTime,
-                                  const QDateTime &updatedTime, const QString &imageName,
-                                  int width, int height, const QString &thumbnailUrl,
-                                  const QString &imageUrl, const QString &thumbnailFile,
-                                  const QString &imageFile, const QString &description,
-                                  int accountId);
+    OneDriveImagePrivate(const QString &imageId, const QString &albumId,
+                         const QString &userId, const QDateTime &createdTime,
+                         const QDateTime &updatedTime, const QString &imageName,
+                         int width, int height, const QString &thumbnailUrl,
+                         const QString &imageUrl, const QString &thumbnailFile,
+                         const QString &imageFile, const QString &description,
+                         int accountId);
+
     QString imageId;
     QString albumId;
     QString userId;
@@ -653,9 +654,7 @@ QMap<int,QString> OneDriveImagesDatabase::accounts(bool *ok) const
     }
 
     QMap<int,QString> result;
-    QSqlQuery query = prepare(QStringLiteral(
-                "SELECT accountId, userId "
-                "FROM accounts "));
+    QSqlQuery query = prepare(QStringLiteral("SELECT accountId, userId FROM accounts "));
     if (!query.exec()) {
         qWarning() << Q_FUNC_INFO << "Unable to fetch account mappings" << query.lastError().text();
         return result;

--- a/src/lib/onedriveimagesdatabase.h
+++ b/src/lib/onedriveimagesdatabase.h
@@ -26,6 +26,7 @@
 #include <QtCore/QSharedPointer>
 
 class OneDriveUserPrivate;
+
 class OneDriveUser
 {
 public:
@@ -53,6 +54,7 @@ private:
 };
 
 class OneDriveAlbumPrivate;
+
 class OneDriveAlbum
 {
 public:
@@ -83,6 +85,7 @@ private:
 };
 
 class OneDriveImagePrivate;
+
 class OneDriveImage
 {
 public:
@@ -119,13 +122,13 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(OneDriveImage)
-    explicit OneDriveImage(const QString & imageId, const QString & albumId,
-                           const QString & userId, const QDateTime & createdTime,
-                           const QDateTime & updatedTime, const QString & imageName,
-                           int width, int height, const QString & thumbnailUrl,
-                           const QString & imageUrl, const QString & thumbnailFile,
-                           const QString & imageFile, const QString & description,
-                           int accountId);
+    OneDriveImage(const QString & imageId, const QString & albumId,
+                  const QString & userId, const QDateTime & createdTime,
+                  const QDateTime & updatedTime, const QString & imageName,
+                  int width, int height, const QString & thumbnailUrl,
+                  const QString & imageUrl, const QString & thumbnailFile,
+                  const QString & imageFile, const QString & description,
+                  int accountId);
 };
 
 bool operator==(const OneDriveUser::ConstPtr &user1, const OneDriveUser::ConstPtr &user2);
@@ -133,11 +136,12 @@ bool operator==(const OneDriveAlbum::ConstPtr &album1, const OneDriveAlbum::Cons
 bool operator==(const OneDriveImage::ConstPtr &image1, const OneDriveImage::ConstPtr &image2);
 
 class OneDriveImagesDatabasePrivate;
+
 class OneDriveImagesDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT
 public:
-    explicit OneDriveImagesDatabase();
+    OneDriveImagesDatabase();
     ~OneDriveImagesDatabase();
 
     // Account manipulation
@@ -195,7 +199,6 @@ protected:
     bool write();
     bool createTables(QSqlDatabase database) const;
     bool dropTables(QSqlDatabase database) const;
-
 
 private:
     Q_DECLARE_PRIVATE(OneDriveImagesDatabase)

--- a/src/lib/semaphore_p.cpp
+++ b/src/lib/semaphore_p.cpp
@@ -173,4 +173,3 @@ bool ProcessMutex::unlock()
 
     return true;
 }
-

--- a/src/lib/semaphore_p.h
+++ b/src/lib/semaphore_p.h
@@ -66,5 +66,4 @@ public:
     bool unlock();
 };
 
-
 #endif // SEMAPHORE_P_H

--- a/src/lib/socialimagesdatabase.cpp
+++ b/src/lib/socialimagesdatabase.cpp
@@ -32,12 +32,13 @@ static const int VERSION = 4;
 
 struct SocialImagePrivate
 {
-    explicit SocialImagePrivate(int accountId,
-                                const QString &imageUrl,
-                                const QString &imageFile,
-                                const QDateTime &createdTime,
-                                const QDateTime &expires,
-                                const QString &imageId);
+    SocialImagePrivate(int accountId,
+                       const QString &imageUrl,
+                       const QString &imageFile,
+                       const QDateTime &createdTime,
+                       const QDateTime &expires,
+                       const QString &imageId);
+
     int accountId;
     QString imageUrl;
     QString imageFile;

--- a/src/lib/socialimagesdatabase.h
+++ b/src/lib/socialimagesdatabase.h
@@ -26,6 +26,7 @@
 #include <QtCore/QSharedPointer>
 
 class SocialImagePrivate;
+
 class SocialImage
 {
 public:
@@ -53,23 +54,25 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(SocialImage)
-    explicit SocialImage(int accountId,
-                         const QString & imageUrl,
-                         const QString & imageFile,
-                         const QDateTime &createdTime,
-                         const QDateTime &expires,
-                         const QString &imageId);
+
+    SocialImage(int accountId,
+                const QString & imageUrl,
+                const QString & imageFile,
+                const QDateTime &createdTime,
+                const QDateTime &expires,
+                const QString &imageId);
 };
 
 bool operator==(const SocialImage::ConstPtr &image1, const SocialImage::ConstPtr &image2);
 
 class SocialImagesDatabasePrivate;
+
 class SocialImagesDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT
 
 public:
-    explicit SocialImagesDatabase();
+    SocialImagesDatabase();
     ~SocialImagesDatabase();
 
     void purgeAccount(int accountId);
@@ -99,7 +102,6 @@ protected:
     bool write();
     bool createTables(QSqlDatabase database) const;
     bool dropTables(QSqlDatabase database) const;
-
 
 private:
     Q_DECLARE_PRIVATE(SocialImagesDatabase)

--- a/src/lib/socialnetworksyncdatabase.cpp
+++ b/src/lib/socialnetworksyncdatabase.cpp
@@ -45,6 +45,7 @@ class SocialNetworkSyncDatabasePrivate: public AbstractSocialCacheDatabasePrivat
 public:
     explicit SocialNetworkSyncDatabasePrivate(SocialNetworkSyncDatabase *q);
     virtual ~SocialNetworkSyncDatabasePrivate();
+
     QList<SocialNetworkSyncData *> queuedData;
 };
 

--- a/src/lib/socialnetworksyncdatabase.h
+++ b/src/lib/socialnetworksyncdatabase.h
@@ -28,7 +28,7 @@ class SocialNetworkSyncDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT
 public:
-    explicit SocialNetworkSyncDatabase();
+    SocialNetworkSyncDatabase();
     ~SocialNetworkSyncDatabase();
 
     QList<int> syncedAccounts(const QString &serviceName, const QString &dataType) const;

--- a/src/lib/socialsyncinterface.h
+++ b/src/lib/socialsyncinterface.h
@@ -27,6 +27,7 @@ class SocialSyncInterface : public QObject
     Q_OBJECT
     Q_ENUMS(SocialNetwork)
     Q_ENUMS(DataType)
+
 public:
     enum SocialNetwork {
         InvalidSocialNetwork,
@@ -51,8 +52,10 @@ public:
         Messages,
         Emails
     };
+
     Q_INVOKABLE static QString socialNetwork(SocialNetwork sn);
     Q_INVOKABLE static QString dataType(DataType t);
+
     static QString profileName(SocialNetwork sn, DataType t);
 };
 

--- a/src/lib/twitternotificationsdatabase.h
+++ b/src/lib/twitternotificationsdatabase.h
@@ -33,7 +33,7 @@ class TwitterNotificationsDatabase: public AbstractSocialCacheDatabase
     Q_OBJECT
 
 public:
-    explicit TwitterNotificationsDatabase();
+    TwitterNotificationsDatabase();
     ~TwitterNotificationsDatabase();
 
     QHash<QString, int> retweetedTweetCounts(int accountId);

--- a/src/lib/twitterpostsdatabase.h
+++ b/src/lib/twitterpostsdatabase.h
@@ -26,7 +26,7 @@ class TwitterPostsDatabase: public AbstractSocialPostCacheDatabase
 {
     Q_OBJECT
 public:
-    explicit TwitterPostsDatabase();
+    TwitterPostsDatabase();
     ~TwitterPostsDatabase();
 
     void addTwitterPost(const QString &identifier, const QString &name, const QString &body,

--- a/src/lib/vkimagesdatabase.cpp
+++ b/src/lib/vkimagesdatabase.cpp
@@ -32,8 +32,8 @@ static const int VERSION = 1;
 
 struct VKUserPrivate
 {
-    explicit VKUserPrivate(const QString &id, const QString &first_name, const QString &last_name,
-                           const QString &photo_src, const QString &photo_file, int accountId);
+    VKUserPrivate(const QString &id, const QString &first_name, const QString &last_name,
+                  const QString &photo_src, const QString &photo_file, int accountId);
 
     QString id;         // user id
     QString first_name;
@@ -130,10 +130,10 @@ bool VKUser::operator==(const VKUser &other) const
 
 struct VKAlbumPrivate
 {
-    explicit VKAlbumPrivate(const QString &id, const QString &owner_id, const QString &title,
-                            const QString &description, const QString &thumb_src,
-                            const QString &thumb_file, int size, int created, int updated,
-                            int accountId);
+    VKAlbumPrivate(const QString &id, const QString &owner_id, const QString &title,
+                   const QString &description, const QString &thumb_src,
+                   const QString &thumb_file, int size, int created, int updated,
+                   int accountId);
 
     QString id;       // album id
     QString owner_id; // user id

--- a/src/lib/vkimagesdatabase.h
+++ b/src/lib/vkimagesdatabase.h
@@ -26,6 +26,7 @@
 #include <QtCore/QSharedPointer>
 
 class VKUserPrivate;
+
 class VKUser
 {
 public:
@@ -54,11 +55,13 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(VKUser)
-    explicit VKUser(const QString &id, const QString &first_name, const QString &last_name,
-                    const QString &photo_src, const QString &photo_file, int accountId);
+
+    VKUser(const QString &id, const QString &first_name, const QString &last_name,
+           const QString &photo_src, const QString &photo_file, int accountId);
 };
 
 class VKAlbumPrivate;
+
 class VKAlbum
 {
 public:
@@ -90,13 +93,14 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(VKAlbum)
-    explicit VKAlbum(const QString &id, const QString &owner_id, const QString &title,
-                     const QString &description, const QString &thumb_src,
-                     const QString &thumb_file, int size, int created, int updated,
-                     int accountId);
+    VKAlbum(const QString &id, const QString &owner_id, const QString &title,
+            const QString &description, const QString &thumb_src,
+            const QString &thumb_file, int size, int created, int updated,
+            int accountId);
 };
 
 class VKImagePrivate;
+
 class VKImage
 {
 public:
@@ -130,13 +134,15 @@ protected:
 
 private:
     Q_DECLARE_PRIVATE(VKImage)
-    explicit VKImage(const QString &id, const QString &album_id, const QString &owner_id,
-                     const QString &text, const QString &thumb_src, const QString &photo_src,
-                     const QString &thumb_file, const QString &photo_file,
-                     int width, int height, int date, int accountId);
+
+    VKImage(const QString &id, const QString &album_id, const QString &owner_id,
+            const QString &text, const QString &thumb_src, const QString &photo_src,
+            const QString &thumb_file, const QString &photo_file,
+            int width, int height, int date, int accountId);
 };
 
 class VKImagesDatabasePrivate;
+
 class VKImagesDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT

--- a/src/lib/vknotificationsdatabase.cpp
+++ b/src/lib/vknotificationsdatabase.cpp
@@ -29,14 +29,14 @@ static const int VERSION = 1;
 
 struct VKNotificationPrivate
 {
-    explicit VKNotificationPrivate(const QString &identifier,
-                                   int accountId,
-                                   const QString &type,
-                                   const QString &fromId,
-                                   const QString &fromName,
-                                   const QString &fromIcon,
-                                   const QString &toId,
-                                   const QDateTime &createdTime);
+    VKNotificationPrivate(const QString &identifier,
+                          int accountId,
+                          const QString &type,
+                          const QString &fromId,
+                          const QString &fromName,
+                          const QString &fromIcon,
+                          const QString &toId,
+                          const QDateTime &createdTime);
 
     QString m_id;
     int m_accountId;

--- a/src/lib/vknotificationsdatabase.h
+++ b/src/lib/vknotificationsdatabase.h
@@ -27,6 +27,7 @@
 #include <QDateTime>
 
 class VKNotificationPrivate;
+
 class VKNotification
 {
 public:
@@ -55,20 +56,23 @@ public:
 
 protected:
     QScopedPointer<VKNotificationPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(VKNotification)
-    explicit VKNotification(const QString &identifier,
-                            int accountId,
-                            const QString &type,
-                            const QString &fromId,
-                            const QString &fromName,
-                            const QString &fromIcon,
-                            const QString &toId,
-                            const QDateTime &createdTime);
+
+    VKNotification(const QString &identifier,
+                   int accountId,
+                   const QString &type,
+                   const QString &fromId,
+                   const QString &fromName,
+                   const QString &fromIcon,
+                   const QString &toId,
+                   const QDateTime &createdTime);
 };
 
 
 class VKNotificationsDatabasePrivate;
+
 class VKNotificationsDatabase: public AbstractSocialCacheDatabase
 {
     Q_OBJECT

--- a/src/lib/vkpostsdatabase.cpp
+++ b/src/lib/vkpostsdatabase.cpp
@@ -83,7 +83,9 @@ VKPostsDatabase::Comments& VKPostsDatabase::Comments::operator=(const VKPostsDat
     return *this;
 }
 
-VKPostsDatabase::Likes::Likes() : count(0), userLikes(false), userCanLike(false), userCanPublish(false) {}
+VKPostsDatabase::Likes::Likes()
+    : count(0), userLikes(false), userCanLike(false), userCanPublish(false)
+{}
 VKPostsDatabase::Likes::~Likes() {}
 
 VKPostsDatabase::Likes::Likes(const VKPostsDatabase::Likes &other)

--- a/src/lib/vkpostsdatabase.h
+++ b/src/lib/vkpostsdatabase.h
@@ -26,7 +26,7 @@ class VKPostsDatabase: public AbstractSocialPostCacheDatabase
 {
     Q_OBJECT
 public:
-    explicit VKPostsDatabase();
+    VKPostsDatabase();
     ~VKPostsDatabase();
 
     class Comments

--- a/src/qml/abstractsocialcachemodel.h
+++ b/src/qml/abstractsocialcachemodel.h
@@ -26,11 +26,11 @@ typedef QMap<int, QVariant> SocialCacheModelRow;
 typedef QList<SocialCacheModelRow> SocialCacheModelData;
 
 class AbstractSocialCacheModelPrivate;
+
 class AbstractSocialCacheModel : public QAbstractListModel
 {
     Q_OBJECT
-    Q_PROPERTY(QString nodeIdentifier READ nodeIdentifier WRITE setNodeIdentifier
-               NOTIFY nodeIdentifierChanged)
+    Q_PROPERTY(QString nodeIdentifier READ nodeIdentifier WRITE setNodeIdentifier NOTIFY nodeIdentifierChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
 
 public:
@@ -55,7 +55,6 @@ Q_SIGNALS:
     void modelUpdated();
 
 protected:
-
     // Methods used to update the model in the C++ side
     void updateData(const SocialCacheModelData &data);
     void updateRow(int row, const SocialCacheModelRow &data);

--- a/src/qml/dropbox/dropboximagecachemodel.cpp
+++ b/src/qml/dropbox/dropboximagecachemodel.cpp
@@ -333,7 +333,7 @@ void DropboxImageCacheModel::queryFinished()
             QMap<int, QVariant> albumMap;
             albumMap.insert(DropboxImageCacheModel::DropboxId, QString());
             // albumMap.insert(DropboxImageCacheModel::Icon, QString());
-            //:  Label for the "show all photos from all albums by this user" option
+            //: Label for the "show all photos from all albums by this user" option
             //% "All"
             albumMap.insert(DropboxImageCacheModel::Title, qtTrId("nemo_socialcache_dropbox_images_model-all-albums"));
             albumMap.insert(DropboxImageCacheModel::Count, count);

--- a/src/qml/dropbox/dropboximagecachemodel.h
+++ b/src/qml/dropbox/dropboximagecachemodel.h
@@ -27,10 +27,8 @@ class DropboxImageCacheModelPrivate;
 class DropboxImageCacheModel: public AbstractSocialCacheModel
 {
     Q_OBJECT
-    Q_PROPERTY(DropboxImageCacheModel::ModelDataType type READ type WRITE setType
-               NOTIFY typeChanged)
-    Q_PROPERTY(DropboxImageDownloader * downloader READ downloader WRITE setDownloader
-               NOTIFY downloaderChanged)
+    Q_PROPERTY(DropboxImageCacheModel::ModelDataType type READ type WRITE setType NOTIFY typeChanged)
+    Q_PROPERTY(DropboxImageDownloader * downloader READ downloader WRITE setDownloader NOTIFY downloaderChanged)
 
     Q_ENUMS(DropboxGalleryRole)
     Q_ENUMS(ModelDataType)

--- a/src/qml/dropbox/dropboximagedownloader.h
+++ b/src/qml/dropbox/dropboximagedownloader.h
@@ -27,6 +27,7 @@
 class DropboxImageCacheModel;
 class DropboxImageDownloaderWorkerObject;
 class DropboxImageDownloaderPrivate;
+
 class DropboxImageDownloader : public AbstractImageDownloader
 {
     Q_OBJECT
@@ -36,7 +37,7 @@ public:
         FullImage
     };
 
-    explicit DropboxImageDownloader(QObject *parent = 0);
+    explicit DropboxImageDownloader(QObject *parent = nullptr);
     virtual ~DropboxImageDownloader();
 
     // tracking object lifetime of models connected to this downloader.

--- a/src/qml/facebook/facebookimagecachemodel.cpp
+++ b/src/qml/facebook/facebookimagecachemodel.cpp
@@ -305,7 +305,7 @@ void FacebookImageCacheModel::queryFinished()
             QMap<int, QVariant> albumMap;
             albumMap.insert(FacebookImageCacheModel::FacebookId, QString());
             // albumMap.insert(FacebookImageCacheModel::Icon, QString());
-            //:  Label for the "show all photos from all albums by this user" option
+            //: Label for the "show all photos from all albums by this user" option
             //% "All"
             albumMap.insert(FacebookImageCacheModel::Title, qtTrId("nemo_socialcache_facebook_images_model-all-albums"));
             albumMap.insert(FacebookImageCacheModel::Count, count);

--- a/src/qml/facebook/facebookimagecachemodel.h
+++ b/src/qml/facebook/facebookimagecachemodel.h
@@ -27,10 +27,8 @@ class FacebookImageCacheModelPrivate;
 class FacebookImageCacheModel: public AbstractSocialCacheModel
 {
     Q_OBJECT
-    Q_PROPERTY(FacebookImageCacheModel::ModelDataType type READ type WRITE setType
-               NOTIFY typeChanged)
-    Q_PROPERTY(FacebookImageDownloader * downloader READ downloader WRITE setDownloader
-               NOTIFY downloaderChanged)
+    Q_PROPERTY(FacebookImageCacheModel::ModelDataType type READ type WRITE setType NOTIFY typeChanged)
+    Q_PROPERTY(FacebookImageDownloader * downloader READ downloader WRITE setDownloader NOTIFY downloaderChanged)
 
     Q_ENUMS(FacebookGalleryRole)
     Q_ENUMS(ModelDataType)

--- a/src/qml/facebook/facebookimagedownloader.h
+++ b/src/qml/facebook/facebookimagedownloader.h
@@ -27,6 +27,7 @@
 class FacebookImageCacheModel;
 class FacebookImageDownloaderWorkerObject;
 class FacebookImageDownloaderPrivate;
+
 class FacebookImageDownloader : public AbstractImageDownloader
 {
     Q_OBJECT

--- a/src/qml/facebook/facebookpostsmodel.h
+++ b/src/qml/facebook/facebookpostsmodel.h
@@ -23,6 +23,7 @@
 #include "abstractsocialcachemodel.h"
 
 class FacebookPostsModelPrivate;
+
 class FacebookPostsModel: public AbstractSocialCacheModel
 {
     Q_OBJECT

--- a/src/qml/generic/socialimagedownloader.h
+++ b/src/qml/generic/socialimagedownloader.h
@@ -26,6 +26,7 @@
 
 class SocialImageCacheModel;
 class SocialImageDownloaderPrivate;
+
 class SocialImageDownloader : public AbstractImageDownloader
 {
     Q_OBJECT

--- a/src/qml/keyproviderhelper.h
+++ b/src/qml/keyproviderhelper.h
@@ -34,18 +34,21 @@ class KeyProviderHelper : public QObject
 
 public:
     explicit KeyProviderHelper(QObject *parent = 0);
+
     QString facebookClientId();
     QString twitterConsumerKey();
     QString twitterConsumerSecret();
     QString oneDriveClientId();
     QString dropboxClientId();
     QString vkClientId();
+
 private:
     void loadFacebook();
     void loadTwitter();
     void loadOneDrive();
     void loadDropbox();
     void loadVk();
+
     bool m_triedLoadingFacebook;
     QString m_facebookClientId;
     bool m_triedLoadingTwitter;

--- a/src/qml/onedrive/onedriveimagecachemodel.cpp
+++ b/src/qml/onedrive/onedriveimagecachemodel.cpp
@@ -329,7 +329,7 @@ void OneDriveImageCacheModel::queryFinished()
             QMap<int, QVariant> albumMap;
             albumMap.insert(OneDriveImageCacheModel::OneDriveId, QString());
             // albumMap.insert(OneDriveImageCacheModel::Icon, QString());
-            //:  Label for the "show all photos from all albums by this user" option
+            //: Label for the "show all photos from all albums by this user" option
             //% "All"
             albumMap.insert(OneDriveImageCacheModel::Title, qtTrId("nemo_socialcache_onedrive_images_model-all-albums"));
             albumMap.insert(OneDriveImageCacheModel::Count, count);

--- a/src/qml/onedrive/onedriveimagecachemodel.h
+++ b/src/qml/onedrive/onedriveimagecachemodel.h
@@ -24,13 +24,12 @@
 #include "onedriveimagedownloader.h"
 
 class OneDriveImageCacheModelPrivate;
+
 class OneDriveImageCacheModel: public AbstractSocialCacheModel
 {
     Q_OBJECT
-    Q_PROPERTY(OneDriveImageCacheModel::ModelDataType type READ type WRITE setType
-               NOTIFY typeChanged)
-    Q_PROPERTY(OneDriveImageDownloader * downloader READ downloader WRITE setDownloader
-               NOTIFY downloaderChanged)
+    Q_PROPERTY(OneDriveImageCacheModel::ModelDataType type READ type WRITE setType NOTIFY typeChanged)
+    Q_PROPERTY(OneDriveImageDownloader * downloader READ downloader WRITE setDownloader NOTIFY downloaderChanged)
 
     Q_ENUMS(OneDriveGalleryRole)
     Q_ENUMS(ModelDataType)
@@ -74,7 +73,7 @@ public:
     void setDownloader(OneDriveImageDownloader *downloader);
 
     // from AbstractListModel
-    QVariant data(const QModelIndex &index, int role) const;
+    QVariant data(const QModelIndex &index, int role) const override;
 
     Q_INVOKABLE void removeImage(const QString &imageId);
 

--- a/src/qml/onedrive/onedriveimagedownloader.h
+++ b/src/qml/onedrive/onedriveimagedownloader.h
@@ -30,6 +30,7 @@
 class OneDriveImageCacheModel;
 class OneDriveImageDownloaderWorkerObject;
 class OneDriveImageDownloaderPrivate;
+
 class OneDriveImageDownloader : public AbstractImageDownloader
 {
     Q_OBJECT

--- a/src/qml/onedrive/onedriveimagedownloader_p.h
+++ b/src/qml/onedrive/onedriveimagedownloader_p.h
@@ -31,6 +31,7 @@
 #include "onedriveimagesdatabase.h"
 
 class OneDriveImageCacheModel;
+
 class OneDriveImageDownloaderPrivate: public AbstractImageDownloaderPrivate
 {
 public:

--- a/src/qml/plugin.cpp
+++ b/src/qml/plugin.cpp
@@ -137,7 +137,7 @@ public:
         qmlRegisterType<VKImageCacheModel>(uri, 1, 0, "VKImageCacheModel");
 
         qmlRegisterSingletonType<VKImageDownloader>(uri, 1, 0, "VKImageDownloader",
-                                                          &vkImageDownloader_provider);
+                                                    &vkImageDownloader_provider);
 
 #ifndef NO_DEPS
         qmlRegisterUncreatableType<SocialSyncInterface>(uri, 1, 0, "SocialSync",

--- a/src/qml/synchelper.cpp
+++ b/src/qml/synchelper.cpp
@@ -26,9 +26,13 @@
     #include <buteosyncfw5/ProfileManager.h>
 #endif
 
-SyncHelper::SyncHelper(QObject *parent) :
-    QObject(parent), QQmlParserStatus(), m_socialNetwork(SocialSyncInterface::InvalidSocialNetwork)
-    , m_dataType(SocialSyncInterface::InvalidDataType), m_complete(false), m_loading(false)
+SyncHelper::SyncHelper(QObject *parent)
+    : QObject(parent)
+    , QQmlParserStatus()
+    , m_socialNetwork(SocialSyncInterface::InvalidSocialNetwork)
+    , m_dataType(SocialSyncInterface::InvalidDataType)
+    , m_complete(false)
+    , m_loading(false)
 {
     m_interface = new Buteo::SyncClientInterface();
     connect(m_interface, &Buteo::SyncClientInterface::syncStatus,

--- a/src/qml/synchelper.h
+++ b/src/qml/synchelper.h
@@ -56,6 +56,7 @@ public:
 
 public Q_SLOTS:
     void sync();
+
 Q_SIGNALS:
     void socialNetworkChanged();
     void dataTypeChanged();

--- a/src/qml/twitter/twitterpostsmodel.h
+++ b/src/qml/twitter/twitterpostsmodel.h
@@ -23,6 +23,7 @@
 #include "abstractsocialcachemodel.h"
 
 class TwitterPostsModelPrivate;
+
 class TwitterPostsModel: public AbstractSocialCacheModel
 {
     Q_OBJECT

--- a/src/qml/vk/vkimagecachemodel.cpp
+++ b/src/qml/vk/vkimagecachemodel.cpp
@@ -354,7 +354,7 @@ void VKImageCacheModel::queryFinished()
             }
 
             albumMap.insert(VKImageCacheModel::AlbumId, QString());
-            //:  Label for the "show all photos from all albums by this user" option
+            //: Label for the "show all photos from all albums by this user" option
             //% "All"
             albumMap.insert(VKImageCacheModel::Text, qtTrId("nemo_socialcache_VK_images_model-all-albums"));
             albumMap.insert(VKImageCacheModel::Count, count);

--- a/src/qml/vk/vkimagecachemodel.h
+++ b/src/qml/vk/vkimagecachemodel.h
@@ -24,6 +24,7 @@
 #include "vkimagedownloader.h"
 
 class VKImageCacheModelPrivate;
+
 class VKImageCacheModel: public AbstractSocialCacheModel
 {
     Q_OBJECT

--- a/src/qml/vk/vkimagedownloader.h
+++ b/src/qml/vk/vkimagedownloader.h
@@ -27,6 +27,7 @@
 class VKImageCacheModel;
 class VKImageDownloaderWorkerObject;
 class VKImageDownloaderPrivate;
+
 class VKImageDownloader : public AbstractImageDownloader
 {
     Q_OBJECT

--- a/src/qml/vk/vkimagedownloader_p.h
+++ b/src/qml/vk/vkimagedownloader_p.h
@@ -31,6 +31,7 @@
 #include "vkimagesdatabase.h"
 
 class VKImageCacheModel;
+
 class VKImageDownloaderPrivate: public AbstractImageDownloaderPrivate
 {
 public:

--- a/src/qml/vk/vkpostsmodel.h
+++ b/src/qml/vk/vkpostsmodel.h
@@ -23,6 +23,7 @@
 #include "abstractsocialcachemodel.h"
 
 class VKPostsModelPrivate;
+
 class VKPostsModel: public AbstractSocialCacheModel
 {
     Q_OBJECT
@@ -48,6 +49,7 @@ public:
         RepostImages,
         Link
     };
+
     explicit VKPostsModel(QObject *parent = 0);
     QHash<int, QByteArray> roleNames() const;
 


### PR DESCRIPTION
Removed bunch of no-op 'explicit' keywords. Not affecting anything without having one parameter available for implicit conversions.

Jolla Ltd copyrights in the common format, not australian proprietary company.